### PR TITLE
change calendar day cell padding

### DIFF
--- a/Sumdays/app/src/main/res/layout/item_day_cell.xml
+++ b/Sumdays/app/src/main/res/layout/item_day_cell.xml
@@ -3,8 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingTop="6dp"
-    android:paddingBottom="6dp">
+    android:paddingTop="10dp"
+    android:paddingBottom="10dp">
 
     <TextView
         android:id="@+id/tv_circle"


### PR DESCRIPTION
## PR Title: [Descriptive title summarizing the change]

### PR Description:
캘린더 day cell 행간을 키웠습니다. 

#### Changes Included:
- [ ] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation
- [x] Change UI design
- [ ] Code refactoring

### Related Issue(s):
X

#### Screenshots (if UI changes were made):
<img width="270" height="600" alt="padding 6dp" src="https://github.com/user-attachments/assets/57966958-dedd-4a3a-822d-feab070f2624" />
<img width="270" height="600" alt="padding 12dp" src="https://github.com/user-attachments/assets/ced6c0b9-d225-4b52-b23b-0a7f160fb2a9" />
  
각각 6dp, 12dp이고 코드는 10dp로 써둠. 

#### Notes for Reviewer:
X

---

### Reviewer Checklist:
- [x] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [x] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [x] Code review comments have been addressed or clarified.

---

### Additional Comments:
Add any other comments or information that might be useful for the
review process.
